### PR TITLE
Fixed wrong tax rate in price details block

### DIFF
--- a/Block/Price/Details.php
+++ b/Block/Price/Details.php
@@ -79,6 +79,7 @@ class Details extends \Magento\Framework\View\Element\Template
     public function setSaleableItem(\Magento\Framework\Pricing\SaleableInterface $saleableItem)
     {
         $this->saleableItem = $saleableItem;
+        $this->unsetData('tax_rate');
     }
 
     /**


### PR DESCRIPTION
The price details block will be used multiple times when rendering product listings and for every iteration, a new saleable item will be set. The getter for tax_rate is cached though and will return the same tax rate for every item in the product list, even if tax rates differ.
This fix unsets the cached tax rate after setting a new saleable item.

Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

This PR fixes issue #46 .

### Proposed changes

... 
